### PR TITLE
NOTKT: Added UV script run for simplicity

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -1,4 +1,11 @@
-# pip install huggingface_hub
+#!/usr/bin/env -S uv run --script
+#
+# requires-python = ">=3.10"
+# /// script
+# dependencies = [
+#   "huggingface_hub"
+# ]
+# ///
 
 from huggingface_hub import HfApi
 import huggingface_hub


### PR DESCRIPTION
This commit adds a small change to the upload script to enables users with uv to run it as:

```bash
uv run upload.py
```

Or, if made exec:

```bash
./upload.py
```